### PR TITLE
refactor: Update to use 'lib' rather than 'utils'

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -22,7 +22,10 @@ local function drawPlayerNumbers()
                 local player = players[i]
                 local serverId = GetPlayerServerId(player.id)
                 if shouldShowPlayerId(playerOptin[serverId].isOnDutyAdmin) then
-                    DrawText3D('['..serverId..']', vec3(player.coords.x, player.coords.y, player.coords.z + 1.0))
+                    qbx.drawText3d({
+                        text = '['..serverId..']',
+                        coords = vec3(player.coords.x, player.coords.y, player.coords.z + 1.0),
+                    })
                 end
             end
             Wait(0)

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -7,7 +7,7 @@ version '1.0.0'
 
 shared_scripts {
     '@ox_lib/init.lua',
-    '@qbx_core/modules/utils.lua',
+    '@qbx_core/modules/lib.lua',
 }
 
 client_script 'client/main.lua'


### PR DESCRIPTION
## Description

Fix for #9 
Ditch utils.lua and move to lib.lua functionality. Removes warnings.

## Checklist

- [ x ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [ x ] My pull request fits the contribution guidelines & code conventions.
