### PR TITLE
chore: mark event qb-scoreboard:server:SetActivityBusy as deprecated

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -25,5 +25,7 @@ local function setActivityBusy(name, bool)
     illegalActions[name].busy = bool
     GlobalState.illegalActions = illegalActions
 end
+
+---@deprecated use the setActivityBusy export instead
 RegisterNetEvent('qb-scoreboard:server:SetActivityBusy', setActivityBusy)
 exports('SetActivityBusy', setActivityBusy)


### PR DESCRIPTION
## Description

The event is used by server-side scripts. Export SetActivityBusy does the same thing.

## Checklist
- [ ] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
