### PR TITLE
feat: caching only visible identifiers at a configurable distance

### DIFF
--- a/config/client.lua
+++ b/config/client.lua
@@ -1,4 +1,5 @@
 return {
+    visibilityDistance = 10,
     openKey = 'HOME',
     toggle = true, -- If true, scoreboard will open/close on button press. If false, scoreboard stays open as long as button is held down.
 


### PR DESCRIPTION
## Description

Configurable ids rendering distance.
Filtering is done every second, not every frame.

## Checklist

- [X] I have personally loaded this code into an updated Qbox project and checked all of its functionality.
- [X] My pull request fits the contribution guidelines & code conventions.
