### PR TITLE
fix(security): restrict activity state updates

### DIFF
--- a/server/main.lua
+++ b/server/main.lua
@@ -22,11 +22,15 @@ lib.callback.register('qbx_scoreboard:server:getScoreboardData', function()
 end)
 
 local function setActivityBusy(name, bool)
+    if type(name) ~= 'string' or type(bool) ~= 'boolean' then return end
+
     local illegalActions = GlobalState.illegalActions
+    if not illegalActions[name] then return end
+
     illegalActions[name].busy = bool
     GlobalState.illegalActions = illegalActions
 end
 
 ---@deprecated use the setActivityBusy export instead
-RegisterNetEvent('qb-scoreboard:server:SetActivityBusy', setActivityBusy)
+AddEventHandler('qb-scoreboard:server:SetActivityBusy', setActivityBusy)
 exports('SetActivityBusy', setActivityBusy)


### PR DESCRIPTION
## Summary
- make the legacy activity update event server-only
- validate activity names and busy values before mutating GlobalState

## Security impact
Prevents arbitrary clients from changing scoreboard illegal-activity state or causing invalid-key errors.

## Validation
- git diff --check
- FiveM Lua lint and CodeQL will run in CI